### PR TITLE
refactor/feat: 증상 도우미 페이지 리팩토링

### DIFF
--- a/frontend/src/api/symptomApi.ts
+++ b/frontend/src/api/symptomApi.ts
@@ -1,74 +1,33 @@
-// src/api/symptomApi.ts
-import type { SymptomRequest, SymptomResponse } from '@/types/symptom';
-import { ENV } from '@/config/env';
+import { API_BASE_URL, API_ENDPOINTS } from "@/lib/constants/api";
+import type { SymptomQuestion } from "@/types/symptom";
 
 /**
- * 증상 분석 API 호출
- * @param request - 증상 응답 데이터
- * @returns AI가 분석한 진단 결과
+ * 온열질환 증상 질문 목록 조회
+ * @returns 질문 목록 (sortOrder 기준 정렬)
+ * @throws API 호출 실패 시 에러
  */
-export async function analyzeSymptoms(
-  request: SymptomRequest
-): Promise<SymptomResponse> {
+export async function fetchSymptomQuestions(): Promise<SymptomQuestion[]> {
   try {
-    const response = await fetch(`${ENV.API_URL}/api/symptoms/analyze`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      `${API_BASE_URL}${API_ENDPOINTS.SYMPTOM_QUESTIONS}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-      body: JSON.stringify(request),
-    });
+    );
 
-    if (!response.ok) {
-      throw new Error(`증상 분석 실패: ${response.status}`);
+    if (!response.ok){
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
 
-    const data: SymptomResponse = await response.json();
-    return data;
-  } catch (error) {
-    console.error('증상 분석 API 오류:', error);
+    const data: SymptomQuestion[] = await response.json();
+
+    return data.sort((a,b) => a.sortOrder - b.sortOrder);
+  }catch(error){
+    console.error('증상 질문 조회 실패:', error);
     throw error;
   }
 }
 
-/**
- * Mock 데이터 (백엔드 API 개발 전 테스트용)
- * 실제 API 완성 후 제거 예정
- */
-export async function analyzeSymptomsMock(
-  request: SymptomRequest
-): Promise<SymptomResponse> {
-  // 실제 API 호출처럼 딜레이 추가
-  await new Promise((resolve) => setTimeout(resolve, 1500));
-
-  // Mock 응답 데이터
-  return {
-    diagnosis:
-      '입력하신 증상을 바탕으로 감기 또는 독감의 가능성이 있습니다. 충분한 휴식과 수분 섭취가 필요합니다.',
-    severity: 'medium',
-    recommendations: [
-      '충분한 휴식을 취하세요',
-      '수분을 많이 섭취하세요',
-      '증상이 3일 이상 지속되면 병원을 방문하세요',
-      '해열제를 복용할 수 있습니다',
-      '주변 사람들과의 접촉을 최소화하세요',
-    ],
-    relatedDiseases: [
-      {
-        name: '독감 (인플루엔자)',
-        probability: 75,
-        description: '발열, 기침, 피로감 등의 증상이 동반되는 바이러스성 질환',
-      },
-      {
-        name: '감기',
-        probability: 65,
-        description: '콧물, 기침, 목 통증 등이 나타나는 상기도 감염',
-      },
-      {
-        name: '코로나19',
-        probability: 45,
-        description: '발열, 기침, 호흡곤란 등이 나타날 수 있는 감염병',
-      },
-    ],
-  };
-}

--- a/frontend/src/data/symptomQuestions.ts
+++ b/frontend/src/data/symptomQuestions.ts
@@ -1,68 +1,7 @@
 // src/data/symptomQuestions.ts
-import type { SymptomQuestion, SymptomResponses } from '@/types/symptom';
+import type {  SymptomResponses } from '@/types/symptom';
 
-/**
- * 증상 자가진단 질문 목록
- * 피그마 디자인에 맞춰 11개 질문으로 구성
- */
-export const SYMPTOM_QUESTIONS: SymptomQuestion[] = [
-  {
-    id: 'chest-pain',
-    text: '가슴 통증이 있나요?',
-    field: 'hasChestPain',
-  },
-  {
-    id: 'breathing',
-    text: '호흡 곤란이 있나요?',
-    field: 'hasDifficultyBreathing',
-  },
-  {
-    id: 'fever',
-    text: '발열이 있나요?',
-    field: 'hasFever',
-  },
-  {
-    id: 'cough',
-    text: '기침이 있나요?',
-    field: 'hasCough',
-  },
-  {
-    id: 'fatigue',
-    text: '피로감이 있나요?',
-    field: 'hasFatigue',
-  },
-  {
-    id: 'headache',
-    text: '두통이 있나요?',
-    field: 'hasHeadache',
-  },
-  {
-    id: 'dizziness',
-    text: '어지러움이 있나요?',
-    field: 'hasDizziness',
-  },
-  {
-    id: 'nausea',
-    text: '메스꺼움이 있나요?',
-    field: 'hasNausea',
-  },
-  {
-    id: 'abdominal-pain',
-    text: '복통이 있나요?',
-    field: 'hasAbdominalPain',
-  },
-  {
-    id: 'joint-pain',
-    text: '관절통이 있나요?',
-    field: 'hasJointPain',
-  },
-  {
-    id: 'runny-nose',
-    text: '콧물이 있나요?',
-    field: 'hasRunnyNose',
-  },
-];
-
+// toDO: api 연동해서 증상 받아오기
 /**
  * 초기 응답 상태 (모든 증상 false)
  */

--- a/frontend/src/hooks/useSymptomQuestions.ts
+++ b/frontend/src/hooks/useSymptomQuestions.ts
@@ -1,0 +1,55 @@
+
+import { useEffect, useState } from 'react';
+import type { SymptomQuestion } from '../types/symptom';
+import { fetchSymptomQuestions } from '@/api/symptomApi';
+export function useSymptomQuestions(){
+  const [questions, setQuestions] = useState<SymptomQuestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadQuestions = async() => {
+      try{
+        setLoading(true);
+        setError(null);
+
+        const data = await fetchSymptomQuestions();
+
+        if(isMounted){
+          setQuestions(data);
+        }
+      }catch(error){
+        if (isMounted){
+          setError(error instanceof Error ? error : new Error('Unknown error'));
+        }
+      }finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadQuestions();
+
+    return ()=>{
+      isMounted = false;
+    };
+  }, []);
+
+  const retry = async() => {
+    setLoading(true);
+    setError(null);
+    try{
+      const data = await fetchSymptomQuestions();
+      setQuestions(data);
+    }catch(error){
+      setError(error instanceof Error ? error : new Error('Unknown error'));   
+    }finally {
+      setLoading(false);
+    }
+  };
+
+  return {questions, loading, error, retry};
+}

--- a/frontend/src/lib/constants/api.ts
+++ b/frontend/src/lib/constants/api.ts
@@ -1,0 +1,5 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export const API_ENDPOINTS = {
+  SYMPTOM_QUESTIONS: '/api/symptom/questions', 
+} as const;

--- a/frontend/src/pages/HelperPage.tsx
+++ b/frontend/src/pages/HelperPage.tsx
@@ -1,99 +1,69 @@
 // src/pages/HelperPage.tsx
 import { useState } from 'react';
-import { ChevronLeft } from 'lucide-react';
-import { SYMPTOM_QUESTIONS, INITIAL_RESPONSES } from '@/data/symptomQuestions';
-import type { SymptomResponses, SymptomResponse } from '@/types/symptom';
-import { analyzeSymptomsMock } from '@/api/symptomApi';
+import type { SymptomResponses, SymptomResponse, SymptomAnswer } from '@/types/symptom';
+import { useSymptomQuestions } from '@/hooks/useSymptomQuestions';
 
 export default function HelperPage() {
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [responses, setResponses] = useState<SymptomResponses>(INITIAL_RESPONSES);
   const [result, setResult] = useState<SymptomResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const [showIntro, setShowIntro] = useState(true);
+  const [isSeleted, setIsSelected] = useState(false);
+  const { questions, loading, error, retry} = useSymptomQuestions();
+  const [answers, setAnswers] = useState<SymptomAnswer[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
 
-  const currentQuestion = SYMPTOM_QUESTIONS[currentQuestionIndex];
-  const isLastQuestion = currentQuestionIndex === SYMPTOM_QUESTIONS.length - 1;
-  const totalQuestions = SYMPTOM_QUESTIONS.length;
+
+  const currentQuestion = questions[currentIndex];
+
+  const handleAnswer = (questionCode: string, answer: boolean) => {
+    setAnswers(prev => [
+      ...prev.filter(a => a.questionCode !== questionCode),
+      { questionCode, answer }
+    ]);
+
+    if(currentIndex < questions.length - 1){
+      setCurrentIndex(prev => prev+1);
+    }else{
+      handleSubmit();
+    }
+  };
+
+  const handleSubmit = () => {
+    console.log('제출:', answers);
+    // TODO: API POST 통신 예정.
+  }
 
   // 시작하기
   const handleStart = () => {
     setShowIntro(false);
   };
 
-  // 답변 처리
-  const handleAnswer = async (answer: boolean) => {
-    // 응답 저장
-    const newResponses = {
-      ...responses,
-      [currentQuestion.field]: answer,
-    };
-    setResponses(newResponses);
+  const handleSelect = () => {
+    setIsSelected(true);
+  }
+  
+  if(loading){
+    return(
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-body text-foreground">질문을 불러오는 중...</p>
+      </div>
+    );
+  }
 
-    if (isLastQuestion) {
-      // 마지막 질문 - AI 분석 요청
-      setIsLoading(true);
-      try {
-        const analysisResult = await analyzeSymptomsMock({
-          responses: newResponses,
-          metadata: {
-            timestamp: new Date().toISOString(),
-          },
-        });
-        setResult(analysisResult);
-      } catch (error) {
-        console.error('분석 실패:', error);
-        alert('증상 분석에 실패했습니다. 다시 시도해주세요.');
-      } finally {
-        setIsLoading(false);
-      }
-    } else {
-      // 다음 질문으로
-      setCurrentQuestionIndex(currentQuestionIndex + 1);
-    }
-  };
-
-  // 이전 질문으로
-  const handleBack = () => {
-    if (currentQuestionIndex > 0) {
-      setCurrentQuestionIndex(currentQuestionIndex - 1);
-    }
-  };
-
-  // 처음부터 다시
-  const handleRestart = () => {
-    setCurrentQuestionIndex(0);
-    setResponses(INITIAL_RESPONSES);
-    setResult(null);
-    setShowIntro(true);
-  };
-
-  // 심각도별 색상
-  const getSeverityColor = (severity: SymptomResponse['severity']) => {
-    switch (severity) {
-      case 'emergency':
-        return 'text-red-600 bg-red-50';
-      case 'high':
-        return 'text-red-500 bg-red-50';
-      case 'medium':
-        return 'text-blue-600 bg-blue-50';
-      case 'low':
-        return 'text-blue-500 bg-blue-50';
-    }
-  };
-
-  const getSeverityText = (severity: SymptomResponse['severity']) => {
-    switch (severity) {
-      case 'emergency':
-        return '🚨 응급';
-      case 'high':
-        return '⚠️ 높음';
-      case 'medium':
-        return '📋 보통';
-      case 'low':
-        return '✅ 낮음';
-    }
-  };
+  if(error){
+    return(
+      <div className="flex flex-col items-center justify-center h-screen gap-4">
+        <p className="text-body text-red-600">
+          질문을 불러오는데 실패했습니다.
+        </p>
+        <button
+          onClick={retry}
+          className="px-4 py-2 bg-blue-100 text-[#191A1C] rounded-lg"
+        >
+          다시 시도
+        </button>
+      </div>
+    );
+  }
 
   // 인트로 화면
   if (showIntro) {
@@ -107,7 +77,7 @@ export default function HelperPage() {
         </p>
         <button
           onClick={handleStart}
-          className="px-12 py-4 bg-blue-600 text-white rounded-xl text-button hover:bg-blue-700 active:bg-blue-800"
+          className="px-10 py-8 bg-blue-100 text-[#191A1C] rounded-3xl text-button hover:bg-blue-200 active:bg-blue-300"
         >
           자가진단 시작하기
         </button>
@@ -115,130 +85,53 @@ export default function HelperPage() {
     );
   }
 
-  // 결과 화면
-  if (result) {
+  if (!isSeleted){
     return (
-      <div className="min-h-[calc(100vh-4rem)] p-6 bg-background">
-        <h1 className="text-h1 mb-6">분석 결과</h1>
-
-        {/* 심각도 */}
-        <div
-          className={`inline-block px-4 py-2 rounded-lg text-button mb-4 ${getSeverityColor(result.severity)}`}
-        >
-          {getSeverityText(result.severity)}
-        </div>
-
-        {/* 진단 */}
-        <div className="bg-white rounded-xl p-5 shadow-sm mb-4">
-          <h2 className="text-h2 mb-3">진단</h2>
-          <p className="text-body leading-relaxed">{result.diagnosis}</p>
-        </div>
-
-        {/* 권장사항 */}
-        <div className="bg-white rounded-xl p-5 shadow-sm mb-4">
-          <h3 className="text-h2 mb-3">권장사항</h3>
-          <ul className="space-y-2">
-            {result.recommendations.map((rec, i) => (
-              <li key={i} className="flex items-start gap-2">
-                <span className="text-blue-600 mt-1">•</span>
-                <span className="text-body flex-1">{rec}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        {/* 관련 질병 */}
-        <div className="bg-white rounded-xl p-5 shadow-sm mb-6">
-          <h3 className="text-h2 mb-3">관련 가능 질병</h3>
-          <div className="space-y-3">
-            {result.relatedDiseases.map((disease, i) => (
-              <div key={i} className="border-b border-gray-100 last:border-0 pb-3 last:pb-0">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-body font-semibold">{disease.name}</span>
-                  <span className="text-caption text-blue-600">{disease.probability}%</span>
-                </div>
-                <p className="text-body-small text-foreground/60">{disease.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* 다시 진단하기 버튼 */}
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-4rem)] p-6 bg-background">
         <button
-          onClick={handleRestart}
-          className="w-full py-4 bg-blue-600 text-white rounded-xl text-button hover:bg-blue-700 active:bg-blue-800"
+          onClick={handleSelect}
+          className="mb-10 px-14 py-5 bg-blue-100 text-[#191A1C] rounded-3xl text-button hover:bg-blue-200 active:bg-blue-300"
         >
-          다시 진단하기
+          음성 안내와
+          <br />
+          자가진단 하기
+        </button>
+        <button
+          onClick={handleSelect}
+          className="px-14 py-5 bg-blue-100 text-[#191A1C] rounded-3xl text-button hover:bg-blue-200 active:bg-blue-300"
+        >
+          문진표를 보고
+          <br />
+          자가진단 하기
         </button>
       </div>
-    );
+    )
   }
-
+  
   // 질문 화면
   return (
     <div className="flex flex-col h-[calc(100vh-4rem)] bg-background">
-      {/* 상단 헤더 */}
-      <div className="p-4 bg-white border-b border-gray-100">
-        <div className="flex items-center gap-3 mb-3">
-          {currentQuestionIndex > 0 && (
-            <button
-              onClick={handleBack}
-              className="p-2 hover:bg-gray-100 rounded-lg active:bg-gray-200"
-              aria-label="이전 질문"
-            >
-              <ChevronLeft size={24} className="text-foreground" />
-            </button>
-          )}
-          <h1 className="text-h2 flex-1">증상 자가진단</h1>
-        </div>
-
-        {/* 진행 바 */}
-        <div className="flex items-center gap-2">
-          <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
-            <div
-              className="h-full bg-blue-600 transition-all duration-300"
-              style={{ width: `${((currentQuestionIndex + 1) / totalQuestions) * 100}%` }}
-            />
-          </div>
-          <span className="text-caption text-foreground/60 min-w-[60px] text-right">
-            {currentQuestionIndex + 1} / {totalQuestions}
-          </span>
-        </div>
-      </div>
-
       {/* 질문 영역 */}
       <div className="flex-1 flex flex-col items-center justify-center p-6">
         <div className="w-full max-w-md">
-          <p className="text-h1 text-center mb-12">{currentQuestion.text}</p>
+          <p className="text-h1 text-center mb-12 text-blue-900">{currentQuestion.questionText}</p>
 
-          <div className="flex gap-4">
+          <div className="flex gap-12 justify-center items-center">
             <button
-              onClick={() => handleAnswer(true)}
-              disabled={isLoading}
-              className="flex-1 py-6 bg-blue-600 text-white rounded-xl text-button hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={() => handleAnswer(currentQuestion.questionCode, true)}
+              className="w-20 h-20 bg-blue-100 text-[#191A1C] rounded-3xl text-button hover:bg-blue-200 active:bg-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               예
             </button>
             <button
-              onClick={() => handleAnswer(false)}
-              disabled={isLoading}
-              className="flex-1 py-6 bg-gray-200 text-foreground rounded-xl text-button hover:bg-gray-300 active:bg-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={() => handleAnswer(currentQuestion.questionCode, false)}
+              className="w-20 h-20 bg-blue-100 text-[#191A1C] rounded-3xl text-button hover:bg-blue-200 active:bg-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               아니오
             </button>
           </div>
         </div>
       </div>
-
-      {/* 로딩 상태 */}
-      {isLoading && (
-        <div className="absolute inset-0 bg-background/80 flex items-center justify-center">
-          <div className="bg-white rounded-xl p-6 shadow-lg text-center">
-            <div className="text-h2 mb-2">분석 중...</div>
-            <div className="text-body text-foreground/60">잠시만 기다려주세요</div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/types/symptom.ts
+++ b/frontend/src/types/symptom.ts
@@ -1,6 +1,25 @@
 // src/types/symptom.ts
 
 /**
+ * 증상 질문 타입 (GET /api/symptom/questions)
+ */
+export interface SymptomQuestion {
+  id: number;
+  questionText: string;
+  questionCode: string;
+  symptomCode: string;
+  sortOrder: number;
+  active: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SymptomAnswer {
+  questionCode: string;
+  answer: boolean;
+}
+
+/**
  * 증상 응답 인터페이스
  * 각 필드는 질문에 대한 Yes(true)/No(false) 응답
  */
@@ -16,15 +35,6 @@ export interface SymptomResponses {
   hasAbdominalPain: boolean; // 복통
   hasJointPain: boolean; // 관절통
   hasRunnyNose: boolean; // 콧물
-}
-
-/**
- * 증상 질문 타입
- */
-export interface SymptomQuestion {
-  id: string;
-  text: string;
-  field: keyof SymptomResponses;
 }
 
 /**


### PR DESCRIPTION
## 요약
- 증상 페이지 Figma 디자인에 맞게 리팩토링
- api 엔드포인트를 통해서 api 호출 기능 개발
- 해당 api 값들 화면에 반영
- 기존에 필요없는 더미데이터 삭제
- 결과화면까지 한 번에 보이던 것을 삭제하고, 새로운 페이지로 개편할 예정.

### ToDo
- 누적된 answer값을 api POST로 보내주고, 결과 값을 받아오기
- 새로운 페이지로 해당 결과값 렌더링